### PR TITLE
DCOPS-20942: Bump aws-java-sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.11.48</version>
+            <version>1.11.880</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Description

Bump aws-java-sdk to 1.11.880.
